### PR TITLE
fix: skip Vite manifest entries without a name property

### DIFF
--- a/src/AspNet.AssetManager.Tests/ManifestServiceTests.cs
+++ b/src/AspNet.AssetManager.Tests/ManifestServiceTests.cs
@@ -45,6 +45,25 @@ public sealed class ManifestServiceTests : IDisposable
                                                     }
                                                     """;
 
+    // Vite emits standalone CSS chunks as root-level entries without a "name" property.
+    // The bundle we look up appears AFTER the nameless entry to ensure the loop iterates past it.
+    private const string HttpClientViteResponseWithNamelessCss = $$"""
+                                                    {
+                                                      "_Layout-abc123.css": {
+                                                        "file": "_Layout-abc123.css",
+                                                        "src": "_Layout-abc123.css"
+                                                      },
+                                                      "Assets/{{TestValues.JsonBundleJs}}": {
+                                                        "file": "{{TestValues.JsonResultBundleJs}}",
+                                                        "name": "{{TestValues.JsonBundleName}}",
+                                                        "src": "{{TestValues.JsonSrcBundleJs}}",
+                                                        "css": [
+                                                          "{{TestValues.JsonResultBundleCss}}"
+                                                        ]
+                                                      }
+                                                    }
+                                                    """;
+
     private const string Bundle = "Bundle.js";
     private const string HttpClientResponse = "File content";
 
@@ -188,6 +207,25 @@ public sealed class ManifestServiceTests : IDisposable
         fileSystemMock.Verify(x => x.File.ReadAllTextAsync(It.IsAny<string>(), CancellationToken.None), Times.Once);
         fileSystemMock.VerifyNoOtherCalls();
         httpClientFactoryMock.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData(TestValues.JsonBundleJs, TestValues.JsonResultBundleJs)]
+    [InlineData(TestValues.JsonBundleCss, TestValues.JsonResultBundleCss)]
+    [InlineData("InvalidBundle.js", null)]
+    public async Task GetFromManifest_ProductionViteManifestWithNamelessEntry_ShouldNotThrow(string bundle, string? resultBundle)
+    {
+        // Arrange
+        var assetConfigurationMock = DependencyMocker.GetAssetConfiguration(TestValues.Production, ManifestType.Vite);
+        var httpClientFactoryMock = DependencyMocker.GetHttpClientFactory(HttpStatusCode.OK, HttpClientViteResponseWithNamelessCss, true);
+        var fileSystemMock = DependencyMocker.GetFileSystem(HttpClientViteResponseWithNamelessCss);
+        _manifestService = new ManifestService(assetConfigurationMock.Object, fileSystemMock.Object, httpClientFactoryMock.Object);
+
+        // Act
+        var result = await _manifestService.GetFromManifestAsync(bundle);
+
+        // Assert
+        result.Should().Be(resultBundle);
     }
 
     [Fact]

--- a/src/AspNet.AssetManager/ManifestService.cs
+++ b/src/AspNet.AssetManager/ManifestService.cs
@@ -118,9 +118,13 @@ internal sealed class ManifestService(IAssetConfiguration assetConfiguration, IF
         foreach (var property in manifest.RootElement.EnumerateObject())
         {
             var entry = property.Value;
-            var name = entry.GetProperty("name").GetString();
 
-            if (name != nameToFind)
+            if (!entry.TryGetProperty("name", out var nameProperty))
+            {
+                continue;
+            }
+
+            if (nameProperty.GetString() != nameToFind)
             {
                 continue;
             }


### PR DESCRIPTION
## Summary

- `GetFromViteManifest` unconditionally called `entry.GetProperty("name")` on every root-level manifest entry, which threw `KeyNotFoundException` as soon as the loop reached a Vite-emitted standalone CSS chunk (those entries only have `file` and `src`, no `name`).
- Replaced with `TryGetProperty` + `continue`, matching the workaround proposed by the reporter.
- Added a regression `[Theory]` covering a manifest where a nameless CSS entry appears before the JS entry being looked up, plus cases for JS lookup, CSS lookup, and an unmatched bundle. Verified the new tests fail at `ManifestService.cs:121` against the old code, and all 94 tests pass with the fix on net8/9/10.

Fixes Baune8D/AspNet.Frontend.Templates#78.

## Test plan

- [x] `dotnet test src/AspNet.AssetManager.Tests` passes on net8.0, net9.0, net10.0
- [x] Confirmed new tests fail with `KeyNotFoundException` when the fix is reverted
- [ ] After release, bump `AspNet.AssetManager` version across the Vite templates in `AspNet.Frontend.Templates`