### PR TITLE
feat: emit type="module" on Vite script bundles

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1,5 +1,6 @@
 is_global = true
 
+dotnet_diagnostic.CA1716.severity = none
 dotnet_diagnostic.SA1101.severity = none
 dotnet_diagnostic.SA1204.severity = none
 dotnet_diagnostic.SA1309.severity = none

--- a/src/AspNet.AssetManager.Tests/Data/GetScriptTagFixture.cs
+++ b/src/AspNet.AssetManager.Tests/Data/GetScriptTagFixture.cs
@@ -107,12 +107,12 @@ internal sealed class GetScriptTagFixture : AssetServiceFixture
     private void SetupBuildScriptTag(string resultBundle, string returnValue)
     {
         TagBuilderMock
-            .Setup(x => x.BuildScriptTag(resultBundle, ScriptLoad))
+            .Setup(x => x.BuildScriptTag(resultBundle, ScriptLoad, null))
             .Returns(returnValue);
     }
 
     private void VerifyBuildScriptTag(string resultBundle)
     {
-        TagBuilderMock.Verify(x => x.BuildScriptTag(resultBundle, ScriptLoad), Times.Once());
+        TagBuilderMock.Verify(x => x.BuildScriptTag(resultBundle, ScriptLoad, null), Times.Once());
     }
 }

--- a/src/AspNet.AssetManager.Tests/TagBuilderTests.cs
+++ b/src/AspNet.AssetManager.Tests/TagBuilderTests.cs
@@ -142,7 +142,7 @@ public sealed class TagBuilderTests
     }
 
     [Fact]
-    public void BuildScriptTag_ProductionVite_ShouldReturnScriptTag()
+    public void BuildScriptTag_ProductionVite_ShouldReturnModuleScriptTag()
     {
         // Arrange
         var assetConfigurationMock = DependencyMocker.GetAssetConfiguration(TestValues.Production, ManifestType.Vite);
@@ -154,9 +154,55 @@ public sealed class TagBuilderTests
         // Assert
         VerifyScriptTag(result);
         result.Should().NotContain("crossorigin=\"anonymous\"")
-            .And.NotContain("type=\"module\"")
+            .And.Contain("type=\"module\"")
             .And.NotContain("async")
             .And.NotContain("defer");
+    }
+
+    [Fact]
+    public void BuildScriptTag_ProductionViteModuleFalse_ShouldOmitTypeModule()
+    {
+        // Arrange
+        var assetConfigurationMock = DependencyMocker.GetAssetConfiguration(TestValues.Production, ManifestType.Vite);
+        _tagBuilder = new TagBuilder(assetConfigurationMock.Object);
+
+        // Act
+        var result = _tagBuilder.BuildScriptTag(Bundle, ScriptLoad.Normal, module: false);
+
+        // Assert
+        VerifyScriptTag(result);
+        result.Should().NotContain("type=\"module\"");
+    }
+
+    [Fact]
+    public void BuildScriptTag_ProductionModuleTrue_ShouldIncludeTypeModule()
+    {
+        // Arrange
+        var assetConfigurationMock = DependencyMocker.GetAssetConfiguration(TestValues.Production);
+        _tagBuilder = new TagBuilder(assetConfigurationMock.Object);
+
+        // Act
+        var result = _tagBuilder.BuildScriptTag(Bundle, ScriptLoad.Normal, module: true);
+
+        // Assert
+        VerifyScriptTag(result);
+        result.Should().Contain("type=\"module\"");
+    }
+
+    [Fact]
+    public void BuildScriptTag_DevelopmentViteModuleFalse_ShouldOmitTypeModule()
+    {
+        // Arrange
+        var assetConfigurationMock = DependencyMocker.GetAssetConfiguration(TestValues.Development, ManifestType.Vite);
+        _tagBuilder = new TagBuilder(assetConfigurationMock.Object);
+
+        // Act
+        var result = _tagBuilder.BuildScriptTag(Bundle, ScriptLoad.Normal, module: false);
+
+        // Assert
+        VerifyScriptTag(result);
+        result.Should().Contain("crossorigin=\"anonymous\"")
+            .And.NotContain("type=\"module\"");
     }
 
     [Fact]

--- a/src/AspNet.AssetManager/AssetService.cs
+++ b/src/AspNet.AssetManager/AssetService.cs
@@ -71,17 +71,17 @@ internal sealed class AssetService : IAssetService
                ?? await GetJsBundleName(fallback).ConfigureAwait(false);
     }
 
-    public async Task<HtmlString> GetScriptTagAsync(string bundle, ScriptLoad load = ScriptLoad.Normal)
+    public async Task<HtmlString> GetScriptTagAsync(string bundle, ScriptLoad load = ScriptLoad.Normal, bool? module = null)
     {
-        return await GetScriptTagAsync(bundle, null, load).ConfigureAwait(false);
+        return await GetScriptTagAsync(bundle, null, load, module).ConfigureAwait(false);
     }
 
-    public async Task<HtmlString> GetScriptTagAsync(string bundle, string? fallback, ScriptLoad load = ScriptLoad.Normal)
+    public async Task<HtmlString> GetScriptTagAsync(string bundle, string? fallback, ScriptLoad load = ScriptLoad.Normal, bool? module = null)
     {
         var file = await GetScriptSrc(bundle, fallback).ConfigureAwait(false);
 
         return file != null
-            ? new HtmlString(_tagBuilder.BuildScriptTag(file, load))
+            ? new HtmlString(_tagBuilder.BuildScriptTag(file, load, module))
             : HtmlString.Empty;
     }
 

--- a/src/AspNet.AssetManager/IAssetService.cs
+++ b/src/AspNet.AssetManager/IAssetService.cs
@@ -61,11 +61,17 @@ public interface IAssetService
     /// <param name="load">
     /// The loading behavior of the script tag (e.g., normal, async, defer). Defaults to normal.
     /// </param>
+    /// <param name="module">
+    /// Controls whether the generated script tag includes the <c>type="module"</c> attribute.
+    /// When <see langword="null"/> (the default), the value is inferred from the configured
+    /// <see cref="ManifestType"/>: Vite manifests default to <see langword="true"/>; other
+    /// manifest types default to <see langword="false"/>. Set explicitly to override.
+    /// </param>
     /// <returns>
     /// A task that represents the asynchronous operation.
     /// The task result contains an HtmlString with the generated script tag.
     /// </returns>
-    Task<HtmlString> GetScriptTagAsync(string bundle, ScriptLoad load = ScriptLoad.Normal);
+    Task<HtmlString> GetScriptTagAsync(string bundle, ScriptLoad load = ScriptLoad.Normal, bool? module = null);
 
     /// <summary>
     /// Generates an HTML script tag for the specified bundle, allowing customization of script loading behavior
@@ -80,11 +86,17 @@ public interface IAssetService
     /// Specifies the script loading behavior, such as normal, async, defer, or both async and defer.
     /// Defaults to the normal script loading behavior.
     /// </param>
+    /// <param name="module">
+    /// Controls whether the generated script tag includes the <c>type="module"</c> attribute.
+    /// When <see langword="null"/> (the default), the value is inferred from the configured
+    /// <see cref="ManifestType"/>: Vite manifests default to <see langword="true"/>; other
+    /// manifest types default to <see langword="false"/>. Set explicitly to override.
+    /// </param>
     /// <returns>
     /// A task that represents the asynchronous operation.
     /// The task result contains an HTML string representing the generated script tag.
     /// </returns>
-    Task<HtmlString> GetScriptTagAsync(string bundle, string? fallback, ScriptLoad load = ScriptLoad.Normal);
+    Task<HtmlString> GetScriptTagAsync(string bundle, string? fallback, ScriptLoad load = ScriptLoad.Normal, bool? module = null);
 
     /// <summary>
     /// Retrieves the hyperlink reference (href) for a specified CSS bundle,

--- a/src/AspNet.AssetManager/ITagBuilder.cs
+++ b/src/AspNet.AssetManager/ITagBuilder.cs
@@ -20,8 +20,14 @@ public interface ITagBuilder
     /// <param name="load">
     /// The script loading behavior, specifying how the script should be loaded (e.g., normal, async, defer).
     /// </param>
+    /// <param name="module">
+    /// Controls whether the generated script tag includes the <c>type="module"</c> attribute.
+    /// When <see langword="null"/> (the default), the value is inferred from the configured
+    /// <see cref="ManifestType"/>: Vite manifests default to <see langword="true"/>; other
+    /// manifest types default to <see langword="false"/>. Set explicitly to override.
+    /// </param>
     /// <returns>A string containing the HTML script tag with the specified configuration.</returns>
-    string BuildScriptTag(string file, ScriptLoad load);
+    string BuildScriptTag(string file, ScriptLoad load, bool? module = null);
 
     /// <summary>
     /// Builds an HTML link tag for including a CSS stylesheet in a web application.

--- a/src/AspNet.AssetManager/ScriptBundleTagHelper.cs
+++ b/src/AspNet.AssetManager/ScriptBundleTagHelper.cs
@@ -54,6 +54,15 @@ public class ScriptBundleTagHelper(
     public bool Defer { get; set; }
 
     /// <summary>
+    /// Gets or sets a value controlling whether the generated script tag includes the
+    /// <c>type="module"</c> attribute. When <see langword="null"/> (the default), the value
+    /// is inferred from the configured <see cref="ManifestType"/>: Vite manifests default to
+    /// <see langword="true"/>; other manifest types default to <see langword="false"/>.
+    /// Set explicitly to override.
+    /// </summary>
+    public bool? Module { get; set; }
+
+    /// <summary>
     /// Processes the tag helper to generate a script tag for a JavaScript bundle.
     /// </summary>
     /// <param name="context">The context for the tag helper execution.</param>
@@ -87,13 +96,13 @@ public class ScriptBundleTagHelper(
 
         output.Attributes.SetAttribute("src", $"{assetConfiguration.AssetsWebPath}{file}");
 
+        if (Module ?? assetConfiguration.ManifestType == ManifestType.Vite)
+        {
+            output.Attributes.SetAttribute("type", "module");
+        }
+
         if (assetConfiguration.DevelopmentMode)
         {
-            if (assetConfiguration.ManifestType == ManifestType.Vite)
-            {
-                output.Attributes.SetAttribute("type", "module");
-            }
-
             output.Attributes.SetAttribute("crossorigin", "anonymous");
         }
 

--- a/src/AspNet.AssetManager/TagBuilder.cs
+++ b/src/AspNet.AssetManager/TagBuilder.cs
@@ -10,17 +10,17 @@ namespace AspNet.AssetManager;
 
 internal sealed class TagBuilder(IAssetConfiguration assetConfiguration) : ITagBuilder
 {
-    public string BuildScriptTag(string file, ScriptLoad load)
+    public string BuildScriptTag(string file, ScriptLoad load, bool? module = null)
     {
         var attributes = new List<string>();
 
+        if (module ?? assetConfiguration.ManifestType == ManifestType.Vite)
+        {
+            attributes.Add("type=\"module\"");
+        }
+
         if (assetConfiguration.DevelopmentMode)
         {
-            if (assetConfiguration.ManifestType == ManifestType.Vite)
-            {
-                attributes.Add("type=\"module\"");
-            }
-
             attributes.Add("crossorigin=\"anonymous\"");
         }
 


### PR DESCRIPTION
## Summary

- Vite always outputs ES modules, so production script tags need `type="module"` or the browser refuses to parse the file's top-level `import` statements. The attribute was previously only emitted in development; this change applies the same default in production for Vite manifests.
- Added an opt-in `Module` property on `ScriptBundleTagHelper` (with matching `bool? module` parameter on `IAssetService.GetScriptTagAsync` and `ITagBuilder.BuildScriptTag`) so the attribute can be forced on or off independent of the manifest type.
- Disabled CA1716 globally so `module` can be used as a parameter name without VB keyword-collision warnings.

## Behavior

| Manifest | Tag helper | Emits `type="module"` |
|---|---|---|
| Vite | `<script-bundle name="x" />` | yes (dev and prod) |
| Vite | `<script-bundle name="x" module="false" />` | no |
| Webpack/KeyValue | `<script-bundle name="x" />` | no |
| Webpack/KeyValue | `<script-bundle name="x" module="true" />` | yes |

## Test plan

- [x] `dotnet build` clean on net8/net9/net10
- [x] `dotnet test` — all 97 tests pass on net8/net9/net10
- [x] Existing `BuildScriptTag_ProductionVite_*` test updated to assert the now-correct behavior
- [x] New tests cover `module: true`/`module: false` overrides in both dev and prod
- [ ] Verify in a downstream Vite template that the production browser error `Uncaught SyntaxError: Cannot use import statement outside a module` no longer occurs after bumping the package reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)